### PR TITLE
convert c++ exception to python on load() and parse()

### DIFF
--- a/cysimdjson/cysimdjson.pyx
+++ b/cysimdjson/cysimdjson.pyx
@@ -65,8 +65,8 @@ cdef extern from "jsoninter.h":
 	cppclass simdjson_parser:
 		simdjson_parser()
 		simdjson_parser(size_t max_capacity)
-		simdjson_element load(string)
-		simdjson_element parse(const char * buf, size_t len, bool realloc_if_needed)
+		simdjson_element load(string) except +
+		simdjson_element parse(const char * buf, size_t len, bool realloc_if_needed) except +
 
 	cdef int getitem_from_element(simdjson_element & element, string & key, simdjson_element & value)
 	cdef int getitem_from_array(simdjson_array & array, int key, simdjson_element & value)


### PR DESCRIPTION
This PR is meant to allow C++ exceptions raise by *simdjson_parser::load* and *simdjson_parser::parse* to be caught from Python. This can happen despite those methods being marked *noexcept* in the original *simdjson* repo.

### Current behaviour
The current behaviour aborts on malformed JSON:
```
$ python
>>> import cysimdjson
>>> cysimdjson.JSONParser().parse(b'{"foo": null,}')
libc++abi.dylib: terminating with uncaught exception of type simdjson::simdjson_error: The JSON document has an improper structure: missing or superfluous commas, braces, missing keys, etc.
[1]    28023 abort      python
$ 
```
or on non-existent files:
```
$ python
>>> import cysimdjson
>>> cysimdjson.JSONParser().load(b'non_existent.json')
 libc++abi.dylib: terminating with uncaught exception of type simdjson::simdjson_error: Error reading the file.
[1]    28793 abort      python
$ 
```

### New behaviour

Raises *RuntimeError* instead, in both cases:
```
>>> cysimdjson.JSONParser().parse(b'{"foo": null,}')
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "cysimdjson/cysimdjson.pyx", line 312, in cysimdjson.JSONParser.load
    cdef simdjson_element doc = self.Parser.load(path)
RuntimeError: The JSON document has an improper structure: missing or superfluous commas, braces, missing keys, etc.
>>> 
```
```
>>> cysimdjson.JSONParser().load(b'non_existent.json')
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "cysimdjson/cysimdjson.pyx", line 312, in cysimdjson.JSONParser.load
    cdef simdjson_element doc = self.Parser.load(path)
RuntimeError: Error reading the file.
>>> 
```

There may be other code paths needing this, but I don't have time to investigate.

### Setup tested

Anaconda Python 3.7.6, MacOS.