### PR TITLE
Create release 26.25 and setup automatic GitHub PyPI workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,70 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch: {}
+
+jobs:
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build --sdist
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+
+  build-wheels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify version matches release tag
+        if: github.event_name == 'release'
+        run: |
+          VERSION=$(sed -n "s/^[[:space:]]*version=[\"']\\([^\"']*\\)[\"'].*/\\1/p" setup.py)
+          TAG="${GITHUB_REF_NAME#v}"
+          if [ "$VERSION" != "$TAG" ]; then
+            echo "setup.py version ($VERSION) does not match tag ($TAG)"
+            exit 1
+          fi
+
+      - uses: pypa/cibuildwheel@v2
+        env:
+          CIBW_BUILD: cp38-* cp39-* cp310-* cp311-* cp312-* cp313-* cp314-*
+          CIBW_SKIP: "*-musllinux_*"
+          CIBW_ARCHS_LINUX: x86_64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: wheels
+          path: wheelhouse/*.whl
+
+  publish:
+    if: github.event_name == 'release'
+    needs: [build-sdist, build-wheels]
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/cysimdjson
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: "*"
+          merge-multiple: true
+          path: dist
+
+      - uses: pypa/gh-action-pypi-publish@release/v1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ extensions = [
 
 setup(
 	name='cysimdjson',
-	version="24.12",
+	version="26.25",
 	description='High-speed JSON parser',
 	long_description=long_description,
 	long_description_content_type='text/markdown',


### PR DESCRIPTION
- Increased version `v26.25` in `setup.py`
- Setup automatic GitHub workflow for automatic publish to PyPI

## Workflow

The workflow has three jobs:

1. `build-sdist`— builds a source tarball with python -m build --sdist
2. `build-wheels` — builds manylinux wheels for Linux x86_64, Python 3.8–3.14, via `cibuildwheel` (same platform coverage as the existing `build-linux-wheel.sh`, plus 3.13/3.14)
3. `publish` — uploads all artifacts to PyPI using [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC, no API token in secrets)